### PR TITLE
ci: add Cloudflare Pages deployment for docs

### DIFF
--- a/.github/workflows/doc-deploy.yml
+++ b/.github/workflows/doc-deploy.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: production-deploy
+  group: doc-deploy-production
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/doc-deploy.yml
+++ b/.github/workflows/doc-deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build documentation site
+        run: pnpm -w run build:doc
+
+      - name: Prepare deploy directory
+        run: |
+          mkdir -p deploy/pj/zudo-design-token-lint
+          cp -r doc/dist/* deploy/pj/zudo-design-token-lint/
+          echo "/ /pj/zudo-design-token-lint/ 302" > deploy/_redirects
+
+      - name: Deploy to Cloudflare Pages
+        run: |
+          npx wrangler@4 pages deploy deploy \
+            --project-name=zudo-design-token-lint \
+            --branch=main \
+            --commit-hash="${GITHUB_SHA}" \
+            --commit-message="Production deploy: ${GITHUB_SHA}"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/doc-preview.yml
+++ b/.github/workflows/doc-preview.yml
@@ -35,35 +35,41 @@ jobs:
         run: pnpm -w run build:doc
 
       - name: Prepare deploy directory
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           mkdir -p deploy/pj/zudo-design-token-lint
           cp -r doc/dist/* deploy/pj/zudo-design-token-lint/
           echo "/ /pj/zudo-design-token-lint/ 302" > deploy/_redirects
 
       - name: Deploy preview to Cloudflare Pages
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
           npx wrangler@4 pages deploy deploy \
             --project-name=zudo-design-token-lint \
             --branch="pr-${PR_NUMBER}" \
             --commit-hash="${GITHUB_SHA}" \
             --commit-message="PR #${PR_NUMBER} preview"
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Comment preview URL on PR
+        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
           PREVIEW_URL="https://pr-${PR_NUMBER}.zudo-design-token-lint.pages.dev/pj/zudo-design-token-lint/"
           SHORT_SHA=$(echo "${GITHUB_SHA}" | head -c 7)
-          BODY="## Docs Preview
+          BODY=$(cat <<EOF
+          ## Docs Preview
 
           ${PREVIEW_URL}
 
-          Deployed from commit ${SHORT_SHA}"
+          Deployed from commit ${SHORT_SHA}
+          EOF
+          )
 
           # Check for existing preview comment
           EXISTING_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \

--- a/.github/workflows/doc-preview.yml
+++ b/.github/workflows/doc-preview.yml
@@ -63,6 +63,7 @@ jobs:
           PREVIEW_URL="https://pr-${PR_NUMBER}.zudo-design-token-lint.pages.dev/pj/zudo-design-token-lint/"
           SHORT_SHA=$(echo "${GITHUB_SHA}" | head -c 7)
           BODY=$(cat <<EOF
+          <!-- cf-pages-preview -->
           ## Docs Preview
 
           ${PREVIEW_URL}
@@ -71,9 +72,9 @@ jobs:
           EOF
           )
 
-          # Check for existing preview comment
+          # Check for existing preview comment (uses hidden HTML marker)
           EXISTING_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | select(.body | contains("Docs Preview")) | .id' | head -1)
+            --jq '.[] | select(.body | contains("<!-- cf-pages-preview -->")) | .id' | head -1)
 
           if [ -n "$EXISTING_ID" ]; then
             gh api "repos/${{ github.repository }}/issues/comments/${EXISTING_ID}" \

--- a/.github/workflows/doc-preview.yml
+++ b/.github/workflows/doc-preview.yml
@@ -1,0 +1,77 @@
+name: Deploy docs preview
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: doc-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build-and-preview:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build documentation site
+        run: pnpm -w run build:doc
+
+      - name: Prepare deploy directory
+        run: |
+          mkdir -p deploy/pj/zudo-design-token-lint
+          cp -r doc/dist/* deploy/pj/zudo-design-token-lint/
+          echo "/ /pj/zudo-design-token-lint/ 302" > deploy/_redirects
+
+      - name: Deploy preview to Cloudflare Pages
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          npx wrangler@4 pages deploy deploy \
+            --project-name=zudo-design-token-lint \
+            --branch="pr-${PR_NUMBER}" \
+            --commit-hash="${GITHUB_SHA}" \
+            --commit-message="PR #${PR_NUMBER} preview"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Comment preview URL on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          PREVIEW_URL="https://pr-${PR_NUMBER}.zudo-design-token-lint.pages.dev/pj/zudo-design-token-lint/"
+          SHORT_SHA=$(echo "${GITHUB_SHA}" | head -c 7)
+          BODY="## Docs Preview
+
+          ${PREVIEW_URL}
+
+          Deployed from commit ${SHORT_SHA}"
+
+          # Check for existing preview comment
+          EXISTING_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | contains("Docs Preview")) | .id' | head -1)
+
+          if [ -n "$EXISTING_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${EXISTING_ID}" \
+              -X PATCH -f body="${BODY}"
+          else
+            gh pr comment "${PR_NUMBER}" --body "${BODY}"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,9 +69,18 @@ Keep the public documentation (`doc/src/content/docs/api/`) in sync when changin
 
 The doc site deploys to `/pj/zudo-design-token-lint/` on Cloudflare Pages. `settings.base` in `doc/src/config/settings.ts` must match.
 
+- **Production**: Push to `main` triggers `.github/workflows/doc-deploy.yml` → deploys to Cloudflare Pages (`main` branch)
+- **PR Preview**: PRs targeting `main` trigger `.github/workflows/doc-preview.yml` → deploys to `pr-<N>.zudo-design-token-lint.pages.dev`
+
+Deploy directory structure: `deploy/pj/zudo-design-token-lint/` with a `_redirects` file routing `/` → `/pj/zudo-design-token-lint/`.
+
+Required secrets: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`.
+
 ## CI / Publish
 
 - `.github/workflows/ci.yml` — test + build + lint on PR and push to main
+- `.github/workflows/doc-deploy.yml` — deploy doc site to Cloudflare Pages on push to main (requires `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`)
+- `.github/workflows/doc-preview.yml` — deploy doc site preview on PRs, posts preview URL as PR comment (requires `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`)
 - `.github/workflows/publish.yml` — publish to npm when a `v*.*.*` tag is pushed (requires `NPM_TOKEN` secret)
 
 ## Publishing


### PR DESCRIPTION
## Summary
- Add production doc deployment workflow (push to `main` → Cloudflare Pages)
- Add PR preview deployment workflow (PR → `pr-<N>.zudo-design-token-lint.pages.dev`)
- Preview URL posted as PR comment with hidden HTML marker for idempotent updates
- Fork PRs gracefully skip deploy (no secrets available)

## Changes
- **`.github/workflows/doc-deploy.yml`** (new): Production deployment on push to main. Builds doc site, prepares `deploy/pj/zudo-design-token-lint/` directory with `_redirects`, deploys via `wrangler@4 pages deploy`
- **`.github/workflows/doc-preview.yml`** (new): PR preview deployment. Same build pipeline, deploys to branch `pr-<N>`, posts preview URL as PR comment. Skips deploy/comment for fork PRs via `github.event.pull_request.head.repo.full_name` guard
- **`CLAUDE.md`**: Updated Deployment and CI/Publish sections with new workflow documentation and required secrets

## Setup Required
Before deployments work, create the Cloudflare Pages project `zudo-design-token-lint` in the Cloudflare dashboard and add `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` as repository secrets.

## Test Plan
- [x] CI (test-and-build) passes
- [ ] Create CF Pages project, verify production deploy on merge to main
- [ ] Open a test PR, verify preview deploy and PR comment