### PR TITLE
fix(doc): prose flow-space selector — :where() cannot start with >

### DIFF
--- a/doc/src/styles/global.css
+++ b/doc/src/styles/global.css
@@ -191,13 +191,19 @@ body {
   line-height: var(--leading-relaxed);
 }
 
-/* ── Flow spacing (vertical rhythm via --flow-space) ── */
+/* ── Flow spacing (vertical rhythm via --flow-space) ──
+ *
+ * NOTE: the `>` combinator must live OUTSIDE `:where()`. A selector inside
+ * `:where()` must start with a compound selector, not a combinator — only
+ * `:has()` accepts relative selectors. Writing `:where(> * + *)` silently
+ * matches nothing and the entire flow-space rhythm becomes dead code.
+ */
 
-.zd-content :where(> * + *) {
+.zd-content > :where(* + *) {
   margin-top: var(--flow-space, var(--spacing-vsp-md));
 }
 
-.zd-content :where(> :first-child) {
+.zd-content > :where(:first-child) {
   margin-top: 0;
 }
 


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-lint/issues/27

---

## Summary

Fixes cramped heading spacing in the doc site prose content (issue #27). The `.zd-content` flow-space rhythm was dead code due to an invalid CSS selector: `.zd-content :where(> * + *)`. The `>` combinator cannot start a selector inside `:where()` — only `:has()` accepts relative selectors. The forgiving-selector-list silently dropped it, so the rule matched nothing. Same bug on the sibling `:first-child` rule. Headings' large `--flow-space` values (e.g. h2's 56px) were never consumed, leaving only the internal `padding-top` as visible top space.

## Root Cause

```css
/* BROKEN — `>` cannot be at the start of a selector inside :where() */
.zd-content :where(> * + *) { margin-top: var(--flow-space, ...); }
.zd-content :where(> :first-child) { margin-top: 0; }
```

`:where()` takes a forgiving-selector-list where each complex selector must start with a compound selector, not a combinator. Only `:has()` accepts relative selectors (those starting with a combinator). Invalid entries are silently dropped.

## Fix

Move `>` outside `:where()` to match the working pattern in the zudo-doc reference implementation:

```css
.zd-content > :where(* + *) { margin-top: var(--flow-space, ...); }
.zd-content > :where(:first-child) { margin-top: 0; }
```

Added a comment block above the flow rule warning future editors not to re-break it.

## Verification

**Computed-style check via Playwright** (all direct children of `article.zd-content` on multiple pages):

| Scenario | Before | After |
|---|---|---|
| h2 marginTop | 0px | **56px** (flowSpace: 3.5rem) |
| Element after heading (p/ul/ol/table/code-block) marginTop | n/a | **0px** (flowSpace: 0) |
| Default flow between non-heading elements | 0px (collapsed into margin-bottom only) | **24px** |
| First child marginTop | 0px | 0px |
| Consecutive paragraphs gap | 24px (via p's margin-bottom) | 24px (margin collapse) |

**Visual check**: full-page screenshots on `/docs/overview/what-is` and `/docs/guide/cli` show heading separation matching the reference layout.

**Codex review**: no regressions or actionable correctness issues found.

**Root package checks** (test, build, lint): all pass.

## Test Plan

- [x] `pnpm test` — 165 tests pass
- [x] `pnpm build` — clean
- [x] `pnpm lint` — prettier clean
- [x] Visual verification on `/docs/overview/what-is` (headings now have 76px of space above: 56px collapsed margin + 20px padding-top)
- [x] Visual verification on `/docs/guide/cli` (table, code blocks, consecutive h2s all spaced correctly)
- [x] Playwright computed-style verification on 20+ direct children across multiple pages
- [x] Codex review passed

## Notes

The project already had `margin-bottom` on h2/h3/h4 (14px), which was working before because it doesn't depend on the flow rule. The fix preserves that — zudo-doc uses a slightly different pattern (`h + :not(h)` for after-heading spacing, no margin-bottom) but aligning that more closely is out of scope for this bug fix; the minimal selector fix is sufficient and avoids broader spacing retune.
