### PR TITLE
Doc site UI fixes: heading styles, spacing, sidebar toggle

### DIFF
--- a/doc/src/components/content/heading-h2.tsx
+++ b/doc/src/components/content/heading-h2.tsx
@@ -11,7 +11,7 @@ export function HeadingH2({ id, children, className, ...rest }: Props) {
   return (
     <h2
       id={id}
-      className={`text-subheading font-bold leading-tight pt-vsp-sm border-t-[3px] border-transparent${className ? ` ${className}` : ''}`}
+      className={`text-subheading font-normal leading-tight pt-vsp-sm border-t-[3px] border-transparent${className ? ` ${className}` : ''}`}
       style={
         {
           borderImage: 'linear-gradient(to right, var(--color-fg), transparent) 1',

--- a/doc/src/components/content/heading-h3.tsx
+++ b/doc/src/components/content/heading-h3.tsx
@@ -11,7 +11,7 @@ export function HeadingH3({ id, children, className, ...rest }: Props) {
   return (
     <h3
       id={id}
-      className={`text-body font-bold leading-snug pt-vsp-xs border-t-[2px] border-transparent${className ? ` ${className}` : ''}`}
+      className={`text-body font-normal leading-snug pt-vsp-xs border-t-[2px] border-transparent${className ? ` ${className}` : ''}`}
       style={
         {
           borderImage: 'linear-gradient(to right, var(--color-muted), transparent) 1',

--- a/doc/src/components/content/heading-h4.tsx
+++ b/doc/src/components/content/heading-h4.tsx
@@ -11,7 +11,7 @@ export function HeadingH4({ id, children, className, ...rest }: Props) {
   return (
     <h4
       id={id}
-      className={`text-body font-semibold leading-snug pt-vsp-xs border-t border-transparent${className ? ` ${className}` : ''}`}
+      className={`text-body font-normal leading-snug pt-vsp-xs border-t border-transparent${className ? ` ${className}` : ''}`}
       style={
         {
           borderImage: 'linear-gradient(to right, var(--color-muted), transparent) 1',

--- a/doc/src/styles/global.css
+++ b/doc/src/styles/global.css
@@ -258,11 +258,6 @@ body {
   outline-offset: 2px;
 }
 
-/* Tighten spacing after headings */
-.zd-content :where(h2 + *, h3 + *, h4 + *, h5 + *, h6 + *) {
-  --flow-space: 0;
-}
-
 /* Consecutive headings: tighter gap */
 .zd-content :where(h2 + h3, h3 + h4, h4 + h5) {
   --flow-space: var(--spacing-vsp-xs);

--- a/doc/src/styles/global.css
+++ b/doc/src/styles/global.css
@@ -603,6 +603,28 @@ pre.astro-code .line .highlighted-word {
   }
 }
 
+/* Sidebar hide/show animation */
+@media (min-width: 1024px) {
+  #desktop-sidebar {
+    transition:
+      transform 200ms ease-in-out,
+      visibility 200ms;
+  }
+
+  html[data-sidebar-hidden] #desktop-sidebar {
+    transform: translateX(calc(-1 * var(--zd-sidebar-w)));
+    visibility: hidden;
+  }
+
+  .zd-sidebar-content-wrapper {
+    transition: margin-left 200ms ease-in-out;
+  }
+
+  html[data-sidebar-hidden] .zd-sidebar-content-wrapper {
+    margin-left: 0;
+  }
+}
+
 /* Sidebar toggle button — left position uses CSS variable */
 @media (min-width: 1024px) {
   .zd-desktop-sidebar-toggle {


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-lint/issues/56

---

## Summary
- Fix heading font weights: change h2/h3/h4 from bold/semibold to normal (400) to match the zudo-doc template's Futura styling
- Fix spacing after headings: remove the `--flow-space: 0` rule that eliminated all spacing after headings, restoring the default 24px gap
- Add missing sidebar hide/show CSS: add transition, transform, and visibility rules so the desktop sidebar toggle actually hides/shows the sidebar with a 200ms slide animation

## Changes
### Heading font weight (`doc/src/components/content/`)
- `heading-h2.tsx`: `font-bold` → `font-normal`
- `heading-h3.tsx`: `font-bold` → `font-normal`
- `heading-h4.tsx`: `font-semibold` → `font-normal`

### Heading spacing (`doc/src/styles/global.css`)
- Removed the `.zd-content :where(h2 + *, ...) { --flow-space: 0 }` rule (4 lines)
- Kept the consecutive-headings rule (`h2 + h3`, etc.) unchanged

### Sidebar toggle (`doc/src/styles/global.css`)
- Added `@media (min-width: 1024px)` block with:
  - `#desktop-sidebar` transition + hidden state (`translateX` + `visibility: hidden`)
  - `.zd-sidebar-content-wrapper` transition + hidden state (`margin-left: 0`)

## Test Plan
- [ ] Verify h2/h3/h4 headings render with `font-weight: 400`
- [ ] Verify spacing after headings is ~24px (not 0)
- [ ] Verify consecutive headings (h2+h3, etc.) still have tighter 14px spacing
- [ ] Verify sidebar toggle button hides/shows sidebar with slide animation
- [ ] Verify content area expands when sidebar is hidden
- [ ] Verify sidebar resizer still works when sidebar is visible

Closes #57, Closes #58, Closes #59