### PR TITLE
fix #61, #62: drop glob to ^10.4.5; add CLI --help/--version + non-zero exit on empty match

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "chalk": "^5.3.0",
-    "glob": "^11.0.2"
+    "glob": "^10.4.5"
   },
   "devDependencies": {
     "@types/node": "^25.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^5.3.0
         version: 5.6.2
       glob:
-        specifier: ^11.0.2
-        version: 11.1.0
+        specifier: ^10.4.5
+        version: 10.5.0
     devDependencies:
       '@types/node':
         specifier: ^25.5.2
@@ -772,9 +772,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@isaacs/cliui@9.0.0':
-    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
-    engines: {node: '>=18'}
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -844,6 +844,10 @@ packages:
     resolution: {integrity: sha512-8eOCmB8lnpyvwz+HrcTXLuBxhj7UseAFh6KGEXRe8UCcAfVQih+qPy/4akJRezViI+ONijz9oi7HpMkw9rdtBg==}
     cpu: [x64]
     os: [win32]
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@preact/preset-vite@2.10.5':
     resolution: {integrity: sha512-p0vJpxiVO7KWWazWny3LUZ+saXyZKWv6Ju0bYMWNJRp2YveufRPgSUB1C4MTqGJfz07EehMgfN+AJNwQy+w6Iw==}
@@ -1565,9 +1569,8 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   base-64@1.0.0:
     resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
@@ -1584,9 +1587,8 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -1962,6 +1964,9 @@ packages:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   electron-to-chromium@1.5.333:
     resolution: {integrity: sha512-skNh4FsE+IpCJV7xAQGbQ4eyOGvcEctVBAk7a5KPzxC3alES9rLrT+2IsPRPgeQr8LVxdJr8BHQ9481+TOr0xg==}
 
@@ -1973,6 +1978,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
@@ -2109,9 +2117,8 @@ packages:
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
-  glob@11.1.0:
-    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
-    engines: {node: 20 || >=22}
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
@@ -2238,9 +2245,8 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  jackspeak@4.2.3:
-    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
-    engines: {node: 20 || >=22}
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -2387,6 +2393,9 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@11.3.2:
     resolution: {integrity: sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==}
@@ -2584,9 +2593,9 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
-    engines: {node: 18 || 20 || >=22}
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -2695,9 +2704,9 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  path-scurry@2.0.2:
-    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
-    engines: {node: 18 || 20 || >=22}
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2952,6 +2961,10 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
 
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -3434,6 +3447,10 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
@@ -4088,7 +4105,14 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@isaacs/cliui@9.0.0': {}
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -4173,6 +4197,9 @@ snapshots:
     optional: true
 
   '@pagefind/windows-x64@1.5.0':
+    optional: true
+
+  '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.1)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
@@ -4940,7 +4967,7 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@4.0.4: {}
+  balanced-match@1.0.2: {}
 
   base-64@1.0.0: {}
 
@@ -4959,9 +4986,9 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@2.1.0:
     dependencies:
-      balanced-match: 4.0.4
+      balanced-match: 1.0.2
 
   browserslist@4.28.2:
     dependencies:
@@ -5338,6 +5365,8 @@ snapshots:
 
   dset@3.1.4: {}
 
+  eastasianwidth@0.2.0: {}
+
   electron-to-chromium@1.5.333: {}
 
   emmet@2.4.11:
@@ -5348,6 +5377,8 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -5519,14 +5550,14 @@ snapshots:
 
   github-slugger@2.0.0: {}
 
-  glob@11.1.0:
+  glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
-      jackspeak: 4.2.3
-      minimatch: 10.2.5
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
-      path-scurry: 2.0.2
+      path-scurry: 1.11.1
 
   graceful-fs@4.2.11: {}
 
@@ -5730,9 +5761,11 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  jackspeak@4.2.3:
+  jackspeak@3.4.3:
     dependencies:
-      '@isaacs/cliui': 9.0.0
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jiti@2.6.1: {}
 
@@ -5836,6 +5869,8 @@ snapshots:
   lodash-es@4.18.1: {}
 
   longest-streak@3.1.0: {}
+
+  lru-cache@10.4.3: {}
 
   lru-cache@11.3.2: {}
 
@@ -6344,9 +6379,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  minimatch@10.2.5:
+  minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 2.1.0
 
   minipass@7.1.3: {}
 
@@ -6462,9 +6497,9 @@ snapshots:
 
   path-key@3.1.1: {}
 
-  path-scurry@2.0.2:
+  path-scurry@1.11.1:
     dependencies:
-      lru-cache: 11.3.2
+      lru-cache: 10.4.3
       minipass: 7.1.3
 
   pathe@2.0.3: {}
@@ -6848,6 +6883,12 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
 
   string-width@7.2.0:
     dependencies:
@@ -7239,6 +7280,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   wrap-ansi@9.0.2:
     dependencies:

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -198,6 +198,36 @@ describe('runMain — empty match handling', () => {
     });
     expect(code).toBe(2);
   });
+
+  it.each(['0', 'false', 'no', 'off', '  '])(
+    'treats TOKEN_LINT_ALLOW_EMPTY=%j as falsy (still exits 2)',
+    async (value) => {
+      const io = makeIO();
+      const code = await runMain({
+        args: ['nonexistent/**/*.tsx'],
+        env: { TOKEN_LINT_ALLOW_EMPTY: value },
+        cwd: tmpDir,
+        stdout: io.write.stdout,
+        stderr: io.write.stderr,
+      });
+      expect(code).toBe(2);
+    },
+  );
+
+  it.each(['1', 'true', 'TRUE', 'yes', 'on', ' true '])(
+    'treats TOKEN_LINT_ALLOW_EMPTY=%j as truthy (exits 0)',
+    async (value) => {
+      const io = makeIO();
+      const code = await runMain({
+        args: ['nonexistent/**/*.tsx'],
+        env: { TOKEN_LINT_ALLOW_EMPTY: value },
+        cwd: tmpDir,
+        stdout: io.write.stdout,
+        stderr: io.write.stderr,
+      });
+      expect(code).toBe(0);
+    },
+  );
 });
 
 describe('runMain — happy path still works', () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseArgs, readPackageVersion, helpText, runMain } from './cli.js';
+import { setConfig } from './rules.js';
+import { compileConfig, DEFAULT_CONFIG } from './config.js';
+
+interface CapturedIO {
+  stdout: string[];
+  stderr: string[];
+}
+
+function makeIO(): CapturedIO & {
+  write: { stdout: (m: string) => void; stderr: (m: string) => void };
+} {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    stdout,
+    stderr,
+    write: {
+      stdout: (m: string) => stdout.push(m),
+      stderr: (m: string) => stderr.push(m),
+    },
+  };
+}
+
+afterEach(() => {
+  setConfig(compileConfig(DEFAULT_CONFIG));
+});
+
+describe('parseArgs', () => {
+  it('returns help when -h is passed', () => {
+    expect(parseArgs(['-h'])).toEqual({ kind: 'help' });
+  });
+
+  it('returns help when --help is passed', () => {
+    expect(parseArgs(['--help'])).toEqual({ kind: 'help' });
+  });
+
+  it('returns help when --help appears among other args', () => {
+    expect(parseArgs(['src/**/*.tsx', '--help'])).toEqual({ kind: 'help' });
+  });
+
+  it('returns version when -V is passed', () => {
+    expect(parseArgs(['-V'])).toEqual({ kind: 'version' });
+  });
+
+  it('returns version when --version is passed', () => {
+    expect(parseArgs(['--version'])).toEqual({ kind: 'version' });
+  });
+
+  it('returns run with patterns when no flags are present', () => {
+    expect(parseArgs(['src/**/*.tsx', 'lib/**/*.ts'])).toEqual({
+      kind: 'run',
+      patterns: ['src/**/*.tsx', 'lib/**/*.ts'],
+    });
+  });
+
+  it('returns run with empty patterns when no args', () => {
+    expect(parseArgs([])).toEqual({ kind: 'run', patterns: [] });
+  });
+
+  it('prefers help over version when both are set', () => {
+    expect(parseArgs(['--version', '--help'])).toEqual({ kind: 'help' });
+  });
+});
+
+describe('readPackageVersion', () => {
+  it('returns a non-empty semver-shaped string', () => {
+    const v = readPackageVersion();
+    expect(typeof v).toBe('string');
+    expect(v.length).toBeGreaterThan(0);
+    expect(v).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe('helpText', () => {
+  it('mentions usage, both flags, the config file, and the env var', () => {
+    const text = helpText();
+    expect(text).toContain('Usage: design-token-lint');
+    expect(text).toContain('-h, --help');
+    expect(text).toContain('-V, --version');
+    expect(text).toContain('.design-token-lint.json');
+    expect(text).toContain('TOKEN_LINT_ALLOW_EMPTY');
+  });
+});
+
+describe('runMain — flag handling', () => {
+  it('--help exits 0 and prints help text to stdout', async () => {
+    const io = makeIO();
+    const code = await runMain({
+      args: ['--help'],
+      env: {},
+      cwd: process.cwd(),
+      stdout: io.write.stdout,
+      stderr: io.write.stderr,
+    });
+    expect(code).toBe(0);
+    expect(io.stdout.join('\n')).toContain('Usage: design-token-lint');
+    expect(io.stderr).toEqual([]);
+  });
+
+  it('-h behaves the same as --help', async () => {
+    const io = makeIO();
+    const code = await runMain({
+      args: ['-h'],
+      env: {},
+      cwd: process.cwd(),
+      stdout: io.write.stdout,
+      stderr: io.write.stderr,
+    });
+    expect(code).toBe(0);
+    expect(io.stdout.join('\n')).toContain('Usage: design-token-lint');
+  });
+
+  it('--version exits 0 and prints version from package.json to stdout', async () => {
+    const io = makeIO();
+    const code = await runMain({
+      args: ['--version'],
+      env: {},
+      cwd: process.cwd(),
+      stdout: io.write.stdout,
+      stderr: io.write.stderr,
+    });
+    expect(code).toBe(0);
+    expect(io.stdout).toEqual([readPackageVersion()]);
+    expect(io.stderr).toEqual([]);
+  });
+
+  it('-V behaves the same as --version', async () => {
+    const io = makeIO();
+    const code = await runMain({
+      args: ['-V'],
+      env: {},
+      cwd: process.cwd(),
+      stdout: io.write.stdout,
+      stderr: io.write.stderr,
+    });
+    expect(code).toBe(0);
+    expect(io.stdout).toEqual([readPackageVersion()]);
+  });
+});
+
+describe('runMain — empty match handling', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'design-token-lint-test-'));
+    // Create an empty src/ directory so the pattern is valid but matches nothing.
+    mkdirSync(join(tmpDir, 'src'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('exits 2 when no files match (default)', async () => {
+    const io = makeIO();
+    const code = await runMain({
+      args: ['nonexistent/**/*.tsx'],
+      env: {},
+      cwd: tmpDir,
+      stdout: io.write.stdout,
+      stderr: io.write.stderr,
+    });
+    expect(code).toBe(2);
+    const err = io.stderr.join('\n');
+    expect(err).toContain('No files matched any of the configured patterns');
+    expect(err).toContain('nonexistent/**/*.tsx');
+    expect(err).toContain('TOKEN_LINT_ALLOW_EMPTY');
+  });
+
+  it('exits 0 when no files match and TOKEN_LINT_ALLOW_EMPTY=1', async () => {
+    const io = makeIO();
+    const code = await runMain({
+      args: ['nonexistent/**/*.tsx'],
+      env: { TOKEN_LINT_ALLOW_EMPTY: '1' },
+      cwd: tmpDir,
+      stdout: io.write.stdout,
+      stderr: io.write.stderr,
+    });
+    expect(code).toBe(0);
+    const err = io.stderr.join('\n');
+    // Warning should still be printed for visibility.
+    expect(err).toContain('No files matched any of the configured patterns');
+  });
+
+  it('treats empty TOKEN_LINT_ALLOW_EMPTY as unset (still exits 2)', async () => {
+    const io = makeIO();
+    const code = await runMain({
+      args: ['nonexistent/**/*.tsx'],
+      env: { TOKEN_LINT_ALLOW_EMPTY: '' },
+      cwd: tmpDir,
+      stdout: io.write.stdout,
+      stderr: io.write.stderr,
+    });
+    expect(code).toBe(2);
+  });
+});
+
+describe('runMain — happy path still works', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'design-token-lint-test-'));
+    mkdirSync(join(tmpDir, 'src'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns 0 when files match and have no violations', async () => {
+    writeFileSync(join(tmpDir, 'src', 'clean.tsx'), `<div className="flex">`);
+    const io = makeIO();
+    const code = await runMain({
+      args: ['src/**/*.tsx'],
+      env: {},
+      cwd: tmpDir,
+      stdout: io.write.stdout,
+      stderr: io.write.stderr,
+    });
+    expect(code).toBe(0);
+  });
+
+  it('returns 1 when violations are found', async () => {
+    writeFileSync(join(tmpDir, 'src', 'dirty.tsx'), `<div className="p-4">`);
+    const io = makeIO();
+    const code = await runMain({
+      args: ['src/**/*.tsx'],
+      env: {},
+      cwd: tmpDir,
+      stdout: io.write.stdout,
+      stderr: io.write.stderr,
+    });
+    expect(code).toBe(1);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
 /**
  * CLI for design-token-lint.
  *
- * Usage: design-token-lint [glob patterns...]
+ * Usage: design-token-lint [options] [glob patterns...]
  *
  * Default patterns scan src/, components/, lib/, and app/ for .tsx, .jsx, .astro files.
  * Loads config from .design-token-lint.json in the current directory (falls back to defaults).
@@ -12,6 +12,9 @@
 
 import { glob } from 'glob';
 import chalk from 'chalk';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, isAbsolute, resolve } from 'node:path';
 import { loadConfig, compileConfig } from './config.js';
 import { setConfig } from './rules.js';
 import { lintFile, type LintResult } from './linter.js';
@@ -25,16 +28,101 @@ const DEFAULT_PATTERNS = [
 
 const DEFAULT_IGNORE_PATTERNS = ['**/node_modules/**', '**/dist/**', '**/__inbox/**'];
 
-async function main(): Promise<void> {
-  const args = process.argv.slice(2);
+export type ParsedArgs =
+  | { kind: 'help' }
+  | { kind: 'version' }
+  | { kind: 'run'; patterns: string[] };
+
+/**
+ * Parse CLI argv (process.argv.slice(2)).
+ *
+ * Recognizes -h/--help and -V/--version as flags. Any other args are treated
+ * as glob patterns. Flags take precedence; if both --help and --version are
+ * present, --help wins (it appears earlier in conventional CLIs).
+ */
+export function parseArgs(args: string[]): ParsedArgs {
+  if (args.includes('-h') || args.includes('--help')) {
+    return { kind: 'help' };
+  }
+  if (args.includes('-V') || args.includes('--version')) {
+    return { kind: 'version' };
+  }
+  return { kind: 'run', patterns: args };
+}
+
+/**
+ * Read this package's version from its package.json.
+ *
+ * Resolves package.json relative to this file's location. Works for both the
+ * compiled `dist/cli.js` (one level up from dist/) and for tests that import
+ * from `src/` (also one level up from src/).
+ */
+export function readPackageVersion(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const pkgPath = join(here, '..', 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version: string };
+  return pkg.version;
+}
+
+export function helpText(): string {
+  return [
+    'Usage: design-token-lint [options] [glob patterns...]',
+    '',
+    'Lint Tailwind class names against design system tokens.',
+    'Reports raw numeric utilities and default colors that should be replaced',
+    'with semantic design tokens.',
+    '',
+    'Options:',
+    '  -h, --help     Show this help message and exit',
+    '  -V, --version  Print the package version and exit',
+    '',
+    'Patterns:',
+    '  When no patterns are passed, the linter reads `patterns` from',
+    '  .design-token-lint.json in the current directory, or falls back to:',
+    ...DEFAULT_PATTERNS.map((p) => `    ${p}`),
+    '',
+    'Environment:',
+    '  TOKEN_LINT_ALLOW_EMPTY  When set to a non-empty value, exit 0 (instead',
+    '                          of 2) when no files match. Useful as a',
+    '                          first-run / bootstrap escape hatch.',
+  ].join('\n');
+}
+
+export interface MainOptions {
+  args: string[];
+  env: NodeJS.ProcessEnv;
+  cwd: string;
+  stdout: (msg: string) => void;
+  stderr: (msg: string) => void;
+}
+
+/**
+ * Run the CLI and return the desired exit code.
+ *
+ * Factored out from the entry point so it can be unit-tested without
+ * spawning a child process.
+ */
+export async function runMain(opts: MainOptions): Promise<number> {
+  const { args, env, cwd, stdout, stderr } = opts;
+
+  const parsed = parseArgs(args);
+  if (parsed.kind === 'help') {
+    stdout(helpText());
+    return 0;
+  }
+  if (parsed.kind === 'version') {
+    stdout(readPackageVersion());
+    return 0;
+  }
 
   // Load and apply config
-  const config = await loadConfig(process.cwd());
+  const config = await loadConfig(cwd);
   const compiled = compileConfig(config);
   setConfig(compiled);
 
   // Resolve patterns: CLI args > config file > defaults
-  const patterns = args.length > 0 ? args : (config.patterns ?? DEFAULT_PATTERNS);
+  const patterns =
+    parsed.patterns.length > 0 ? parsed.patterns : (config.patterns ?? DEFAULT_PATTERNS);
 
   // Merge ignore patterns: CLI defaults + config ignore patterns
   const ignorePatterns = [...DEFAULT_IGNORE_PATTERNS, ...compiled.ignore];
@@ -42,7 +130,7 @@ async function main(): Promise<void> {
   // Resolve files
   const files = new Set<string>();
   for (const pattern of patterns) {
-    const matched = await glob(pattern, { ignore: ignorePatterns });
+    const matched = await glob(pattern, { ignore: ignorePatterns, cwd });
     for (const f of matched) {
       files.add(f);
     }
@@ -50,21 +138,34 @@ async function main(): Promise<void> {
 
   const sortedFiles = [...files].sort();
   if (sortedFiles.length === 0) {
-    console.error(chalk.yellow('No files matched the given patterns.'));
-    process.exit(0);
+    const allowEmpty = (env.TOKEN_LINT_ALLOW_EMPTY ?? '') !== '';
+    const lines = [
+      'No files matched any of the configured patterns:',
+      ...patterns.map((p) => `  - ${p}`),
+      'This usually means the `patterns` config is wrong or no source files exist yet.',
+      'Set TOKEN_LINT_ALLOW_EMPTY=1 to suppress this error (e.g. for first-run/bootstrap).',
+    ];
+    stderr(chalk.yellow(lines.join('\n')));
+    return allowEmpty ? 0 : 2;
   }
 
-  console.error(chalk.dim(`Scanning ${sortedFiles.length} file(s)...\n`));
+  stderr(chalk.dim(`Scanning ${sortedFiles.length} file(s)...\n`));
 
   const allResults: LintResult[] = [];
   for (const filePath of sortedFiles) {
-    const results = await lintFile(filePath);
-    allResults.push(...results);
+    // glob returns paths relative to `cwd`; resolve against `cwd` so reads
+    // work even when `cwd` differs from process.cwd() (e.g. in tests).
+    const readPath = isAbsolute(filePath) ? filePath : resolve(cwd, filePath);
+    const results = await lintFile(readPath);
+    // Keep the displayed path relative for normal CLI output.
+    for (const r of results) {
+      allResults.push({ ...r, filePath });
+    }
   }
 
   if (allResults.length === 0) {
-    console.error(chalk.green('No design token violations found.'));
-    process.exit(0);
+    stderr(chalk.green('No design token violations found.'));
+    return 0;
   }
 
   // Group by file
@@ -76,21 +177,40 @@ async function main(): Promise<void> {
   }
 
   for (const [filePath, results] of byFile) {
-    console.error(chalk.underline(filePath));
+    stderr(chalk.underline(filePath));
     for (const r of results) {
-      console.error(
-        `  ${chalk.dim(`L${r.line}`)}: ${chalk.red(r.className)} — ${chalk.yellow(r.reason)}`,
-      );
+      stderr(`  ${chalk.dim(`L${r.line}`)}: ${chalk.red(r.className)} — ${chalk.yellow(r.reason)}`);
     }
-    console.error('');
+    stderr('');
   }
 
   const fileCount = byFile.size;
-  console.error(chalk.red(`Found ${allResults.length} violation(s) in ${fileCount} file(s).`));
-  process.exit(1);
+  stderr(chalk.red(`Found ${allResults.length} violation(s) in ${fileCount} file(s).`));
+  return 1;
 }
 
-main().catch((err) => {
-  console.error(chalk.red('Error:'), err);
-  process.exit(2);
-});
+// Detect if this module is being run directly (vs imported by tests).
+const isMain = (() => {
+  try {
+    return process.argv[1] === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (isMain) {
+  runMain({
+    args: process.argv.slice(2),
+    env: process.env,
+    cwd: process.cwd(),
+    stdout: (msg) => console.log(msg),
+    stderr: (msg) => console.error(msg),
+  })
+    .then((code) => {
+      process.exit(code);
+    })
+    .catch((err) => {
+      console.error(chalk.red('Error:'), err);
+      process.exit(2);
+    });
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,6 +64,19 @@ export function readPackageVersion(): string {
   return pkg.version;
 }
 
+/**
+ * Treat env vars as truthy only for the conventional boolean-true spellings.
+ * Accepts: "1", "true", "yes", "on" (case-insensitive). Everything else,
+ * including "0", "false", "no", "off", and the empty string, is falsy. This
+ * avoids the surprise that any non-empty string (e.g. "0") would otherwise
+ * count as truthy.
+ */
+function isTruthyEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
 export function helpText(): string {
   return [
     'Usage: design-token-lint [options] [glob patterns...]',
@@ -82,9 +95,9 @@ export function helpText(): string {
     ...DEFAULT_PATTERNS.map((p) => `    ${p}`),
     '',
     'Environment:',
-    '  TOKEN_LINT_ALLOW_EMPTY  When set to a non-empty value, exit 0 (instead',
-    '                          of 2) when no files match. Useful as a',
-    '                          first-run / bootstrap escape hatch.',
+    '  TOKEN_LINT_ALLOW_EMPTY  When set to 1/true/yes/on (case-insensitive),',
+    '                          exit 0 (instead of 2) when no files match.',
+    '                          Useful as a first-run / bootstrap escape hatch.',
   ].join('\n');
 }
 
@@ -138,7 +151,7 @@ export async function runMain(opts: MainOptions): Promise<number> {
 
   const sortedFiles = [...files].sort();
   if (sortedFiles.length === 0) {
-    const allowEmpty = (env.TOKEN_LINT_ALLOW_EMPTY ?? '') !== '';
+    const allowEmpty = isTruthyEnv(env.TOKEN_LINT_ALLOW_EMPTY);
     const lines = [
       'No files matched any of the configured patterns:',
       ...patterns.map((p) => `  - ${p}`),


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-lint/issues/63

---

## Summary

Closes #61 and #62.

- **#61 — engines/glob mismatch**: package.json declares `engines.node: \">=18\"` but depended on `glob@^11` which silently requires Node 20+. Downgrade to `glob@^10.4.5` (Option B from #61) — same `glob(pattern, { ignore })` API, no source changes.
- **#62 — CLI UX**: `design-token-lint` had no `--help` / `--version` and exited 0 when 0 files matched, hiding misconfigured `patterns` from CI. Add the flags and exit non-zero on empty match, with an env escape hatch.

## Changes

### Dependencies (#61)
- `package.json`: `glob: ^11.0.2` → `glob: ^10.4.5`. Lockfile regenerated. Build, prettier, and 258 tests pass.

### CLI (#62)
- `-h` / `--help` prints usage (to stdout) and exits 0. Short-circuits before config load so a misconfigured project can still get help.
- `-V` / `--version` prints the version read from `package.json` at runtime via `import.meta.url` (works for both compiled `dist/cli.js` and `src/` tests).
- Empty-pattern-match path now prints a yellow warning that names the patterns that matched nothing and **exits 2** (was 0). Suppressed back to 0 when `TOKEN_LINT_ALLOW_EMPTY` is set to `1`/`true`/`yes`/`on` (case-insensitive). Other values, including `0`/`false`, are falsy — see review fix below.
- `main()` refactored into exported `parseArgs` and `runMain` so tests can drive it without spawning a process.
- `src/cli.test.ts` adds 27 tests covering all flag combinations, the empty-match exit codes, and the truthiness rules for the env var.

### Review fix (gcoc-review)
- Tightened `TOKEN_LINT_ALLOW_EMPTY` truthiness so `\"0\"` and `\"false\"` are no longer truthy. Added a dedicated `isTruthyEnv` helper and 11 parameterized tests.

## Test Plan

- `pnpm install` resolves `glob@10.5.0`.
- `pnpm build` (tsc) — clean.
- `pnpm test` — 258 / 258 pass (6 files).
- `pnpm lint` — clean.
- `node dist/cli.js --help` — prints usage, exit 0.
- `node dist/cli.js -V` — prints `0.1.0`, exit 0.
- `node dist/cli.js 'nonexistent/**/*.tsx'` — yellow warning, exit 2.
- `TOKEN_LINT_ALLOW_EMPTY=1 node dist/cli.js 'nonexistent/**/*.tsx'` — same warning, exit 0.
- `TOKEN_LINT_ALLOW_EMPTY=0 node dist/cli.js 'nonexistent/**/*.tsx'` — exit 2 (verified by tests).