### PR TITLE
feat(skill): make /l-make-release auto-publish end-to-end (one invoke → npm)

### DIFF
--- a/.claude/skills/l-make-release/SKILL.md
+++ b/.claude/skills/l-make-release/SKILL.md
@@ -69,14 +69,16 @@ CUR=$(node -p "require('./package.json').version")
 git tag -l "v$CUR"   # empty output = no tag yet for the current version
 ```
 
-- **If `v$CUR` does NOT exist** and the working tree is clean: the current version is un-tagged. Find the commit that introduced it (do NOT assume it is `HEAD`):
+- **If `v$CUR` does NOT exist**: the current version is un-tagged. First check the working tree:
+  - **Dirty** (`git status --porcelain` non-empty) → **STOP**. An un-tagged current version plus uncommitted changes is ambiguous — a half-finished bump, an aborted prior run, or stray edits. Ask the user to commit, stash, or discard the changes before re-running; do NOT resume or bump over a dirty tree.
+  - **Clean** → this is a RESUME. Find the commit that introduced the current version (do NOT assume it is `HEAD`):
 
-  ```bash
-  BUMP_SHA=$(git log -1 --format=%H -S"\"version\": \"$CUR\"" -- package.json)
-  ```
+    ```bash
+    BUMP_SHA=$(git log -1 --format=%H -S"\"version\": \"$CUR\"" -- package.json)
+    ```
 
-  Tell the user the bump for `v$CUR` is already committed (`$BUMP_SHA`) and offer to **RESUME** — this skips Steps 2–6 (bump / changelog / commit) and continues from **Step 7** (CI wait) onward, tagging **`$BUMP_SHA`**, through the same push-tag → publish → GitHub Release path. The resume confirmation stands in for the Step 3 gate. If `$BUMP_SHA` is not the current `HEAD`, later commits landed on top — surface that and let the user choose: tag `$BUMP_SHA` as-is, or abort and cut a fresh bump that includes the newer commits.
-- **If `v$CUR` already exists**: the current version is released. Proceed with a normal cold-start bump (Steps 2–6). Require a **clean working tree** (`git status --porcelain` empty) on this cold-start path.
+    Tell the user the bump for `v$CUR` is already committed (`$BUMP_SHA`) and offer to **RESUME** — this skips Steps 2–6 (bump / changelog / commit) and continues from **Step 7** (CI wait) onward, tagging **`$BUMP_SHA`**, through the same push-tag → publish → GitHub Release path. The resume confirmation stands in for the Step 3 gate. If `$BUMP_SHA` is not the current `HEAD`, later commits landed on top — surface that and let the user choose: tag `$BUMP_SHA` as-is, or abort and cut a fresh bump that includes the newer commits.
+- **If `v$CUR` already exists**: the current version is released. Proceed with a normal cold-start bump (Steps 2–6). Require a **clean working tree** (`git status --porcelain` empty) on this cold-start path too.
 
 ## Step 2: Determine Next Version
 
@@ -231,14 +233,20 @@ If `/watch-ci` is unavailable in the running session, fall back to a direct poll
 gh run watch "$(gh run list --branch main --commit <BUMP_SHA> --limit 1 --json databaseId -q '.[0].databaseId')" --exit-status
 ```
 
-If CI fails, fix the issue, commit the fix, push, and re-watch before proceeding. Do not advance to the tag push until CI on the bump commit is green.
+If CI fails, fix the issue, commit the fix, push, and re-watch before proceeding. **A fix commit moves the green commit off the original `BUMP_SHA` — refresh it so the tag in Step 8 points at the commit whose CI actually passed, never the stale pre-fix commit:**
+
+```bash
+BUMP_SHA=$(git rev-parse HEAD)   # only after CI on THIS commit is green
+```
+
+Do not advance to the tag push until CI on the bump commit is green.
 
 ## Step 8: Push the Tag (triggers the publish)
 
-Mint the tag on the bump commit and push it — the push is what fires `.github/workflows/publish.yml`:
+Mint the tag on the **green** bump commit and push it — the push is what fires `.github/workflows/publish.yml`. Tag `$BUMP_SHA` as carried from Step 7 (refreshed if a CI-fix commit was added there), never a stale pre-fix commit:
 
 ```bash
-git tag "v<version>" <BUMP_SHA>
+git tag "v<version>" "$BUMP_SHA"
 git push origin "v<version>"
 ```
 
@@ -246,13 +254,22 @@ The `v*.*.*` tag push triggers the publish workflow. Do NOT ask "push the tag no
 
 ## Step 9: Watch the Publish Workflow
 
-Find the run `publish.yml` started for this tag (allow a few seconds for it to register), then watch it to completion:
+Find the run `publish.yml` started for this tag and watch it to completion. Match the run by its **head commit** (`$BUMP_SHA`, the tagged commit) — that is deterministic for a tag push, whereas `headBranch` is often empty for tag events. Retry until the run registers, and **fail rather than fall back to an unrelated run** (watching an older successful release would let Step 10 create a Release before this version actually published):
 
 ```bash
-PUBLISH_RUN=$(gh run list --workflow publish.yml --limit 5 \
-  --json databaseId,headBranch -q '[.[] | select(.headBranch=="v<version>")][0].databaseId')
-# Fallback if the tag-ref filter returns nothing: the most recent publish.yml run
-[ -z "$PUBLISH_RUN" ] && PUBLISH_RUN=$(gh run list --workflow publish.yml --limit 1 --json databaseId -q '.[0].databaseId')
+PUBLISH_RUN=""
+for i in $(seq 1 12); do
+  PUBLISH_RUN=$(gh run list --workflow publish.yml --limit 15 \
+    --json databaseId,headSha,event \
+    -q "[.[] | select(.headSha==\"$BUMP_SHA\")][0].databaseId")
+  [ -n "$PUBLISH_RUN" ] && break
+  sleep 5
+done
+if [ -z "$PUBLISH_RUN" ]; then
+  echo "ERROR: could not find the publish.yml run for v<version> (commit $BUMP_SHA)." >&2
+  echo "Inspect 'gh run list --workflow publish.yml' and watch the correct run manually before creating the Release." >&2
+  exit 1
+fi
 gh run watch "$PUBLISH_RUN" --exit-status
 ```
 

--- a/.claude/skills/l-make-release/SKILL.md
+++ b/.claude/skills/l-make-release/SKILL.md
@@ -1,16 +1,22 @@
 ---
-description: "Release @takazudo/zudo-design-token-lint — bump the version, write a bilingual changelog, commit + push, wait for CI, then STOP right before the tag push that triggers the npm publish workflow. The user decides when to push the tag. Triggers on rough requests like \"bump version\", \"cut a release\", \"release\", \"make a release\"."
+description: "Release @takazudo/zudo-design-token-lint end-to-end — bump the version, write a bilingual changelog, commit + push, wait for CI, push the v* tag (which triggers the npm publish workflow), watch it to success, then create the GitHub Release. One invoke → published on npm: the single human gate is the Step 3 version-bump proposal, and confirming it authorizes the whole flow through publish. Triggers on rough requests like \"bump version\", \"cut a release\", \"release\", \"make a release\"."
 user-invocable: true
 argument-description: "Optional: major, minor, patch, next, stable — version bump strategy. Or: cancel — abort/teardown a not-yet-published release."
 ---
 
 # /l-make-release
 
-Orchestrator for releasing `@takazudo/zudo-design-token-lint`. Bumps the version, writes a bilingual changelog (EN + JA), commits + pushes to `main`, waits for CI, and **stops right before pushing the `v<version>` tag**. Pushing that tag is what triggers `.github/workflows/publish.yml`, which publishes to npm. The user decides when to push.
+End-to-end release orchestrator for `@takazudo/zudo-design-token-lint`. It bumps the version, writes a bilingual changelog (EN + JA), commits + pushes to `main`, waits for CI, then **pushes the `v<version>` tag** — which triggers `.github/workflows/publish.yml` (build + test + `pnpm publish`) — watches that publish run to success, and creates the GitHub Release. **One invocation takes the release all the way to npm.**
+
+The single human gate is the **Step 3 proposal** (current → new version + categorized changelog). Confirming it authorizes the entire flow through publish + GitHub Release — there is no second "push the tag now?" prompt.
 
 ## Invocation & confirmation
 
-This skill is **model-invocable**: a rough natural-language request like "bump version", "cut a release", or "release" may trigger it. **It must never mutate anything before the user explicitly confirms.** Steps 1–3 are read-only (preconditions, version computation, change analysis); the first mutation is Step 4. Always present the Step 3 proposal (current → new version + categorized changelog) and **wait for explicit user confirmation** before proceeding to Step 4. If the trigger was a loose phrase, restate the proposed bump plainly so the user can catch a wrong version strategy before anything is written.
+This skill is **model-invocable**: a rough natural-language request like "bump version", "cut a release", or "release" may trigger it. **It must never mutate anything before the user explicitly confirms.** Steps 1–3 are read-only (preconditions, version computation, change analysis); the first mutation is Step 4.
+
+There is **one gate**: the Step 3 proposal. Confirming it authorizes the whole flow — bump, push, CI, tag, publish, and GitHub Release. Do **not** add a second "push the tag now?" prompt; the user already decided at Step 3. The only thing that can halt the flow after Step 3 is a **build/test failure** (Step 5, before anything is pushed) or a **publish-workflow failure** (Step 9, after the tag is pushed) — see [Failure Recovery](#failure-recovery).
+
+If the trigger was a loose phrase, restate the proposed bump plainly at Step 3 so the user can catch a wrong version strategy before anything is written.
 
 **Cancel mode.** Invoking `/l-make-release cancel` — or a request like "cancel the release", "abort the release" — does NOT bump anything. It jumps straight to [Cancelling a release](#cancelling-a-release) below to undo a not-yet-published release (delete a local unpushed tag, or revert a bump commit that is still HEAD).
 
@@ -18,36 +24,59 @@ This skill is **model-invocable**: a rough natural-language request like "bump v
 
 - **Single npm package** — `@takazudo/zudo-design-token-lint`. The **version source-of-truth is the root `package.json`** (`version` field).
 - The workspace also contains an Astro doc site under `doc/` (`pnpm-workspace.yaml`). It is **not** published to npm and has no version of its own to bump.
+- The current version is on the `1.x` line, so the version strategy below is the prerelease (`-next.N`) → stable promotion model — see Step 2.
 
 ## How publishing works (read before changing anything)
 
 ```
-/l-make-release  →  bump + changelog + commit + push main  →  CI green  →  STOP
-                                                                            │
-                                          user runs: git push origin v<version>
-                                                                            │
-                                          .github/workflows/publish.yml fires
-                                                                            │
-                                          builds + tests + `pnpm publish`  →  npm
+/l-make-release  →  confirm bump (Step 3)  →  bump + changelog + commit + push main  →  CI green
+                                                                                          │
+                                                  skill pushes:  git push origin v<version>
+                                                                                          │
+                                                  .github/workflows/publish.yml fires
+                                                                                          │
+                                                  builds + tests + `pnpm publish`  →  npm
+                                                                                          │
+                                                  skill watches the run, then creates the GitHub Release
 ```
 
-The publish workflow triggers on a pushed `v*.*.*` tag — NOT on a GitHub Release. There is no draft-Release intermediate. The irreversible step is **`git push origin v<version>`**; everything this skill does happens before it.
+The publish workflow triggers on a pushed `v*.*.*` tag — NOT on a GitHub Release. The skill creates the GitHub Release **after** the publish run succeeds (so a failed publish leaves no orphaned Release). The irreversible step is the **tag push** (`git push origin v<version>`); confirming the Step 3 proposal is what authorizes it.
 
 ## Boundaries
 
-- This skill **never** pushes the `v<version>` tag — it prints the command for the user to run.
-- This skill **never** publishes to npm — `publish.yml` does that when the tag is pushed.
+- The skill **does** push the `v<version>` tag, **does** trigger the publish, and **does** create the GitHub Release — but only after the Step 3 confirmation. It never bypasses that confirmation.
+- A **build/test failure** (Step 5) aborts the flow **before** any commit or push — nothing reaches the remote.
+- The skill never runs `pnpm publish` directly — publishing is `publish.yml`'s job, triggered by the tag push.
+- npm cannot re-publish a version. If the publish workflow fails *after* the tag is pushed (Step 9), the fix is to cut a **new** version, not to retry the same one — see [Failure Recovery](#failure-recovery).
 
 ## Step 1: Preconditions
 
 Verify ALL of the following. If any check fails, stop with a clear message.
 
 1. Current branch is `main` (`git branch --show-current`).
-2. Working tree is clean (`git status --porcelain` returns empty).
-3. `gh` CLI is authenticated (`gh auth status`).
-4. Local `main` is up to date with `origin/main` (`git fetch origin && git status -sb`). If behind, pull first.
-5. Fetch tags so the changelog base is correct: `git fetch --tags origin`.
-6. At least one `v*` tag SHOULD exist (`git tag -l 'v*'`). If none exists this is the very **first** release — see the note in Step 3. (The initial `v1.0.0` was bootstrapped manually outside this skill; from then on this skill drives every release.)
+2. `gh` CLI is authenticated (`gh auth status`).
+3. Local `main` is up to date with `origin/main` (`git fetch origin && git status -sb`). If behind, pull first.
+4. Fetch tags so the changelog base is correct: `git fetch --tags origin`.
+5. At least one `v*` tag SHOULD exist (`git tag -l 'v*'`). If none exists this is the very **first** release — see the note in Step 3. (The initial `v1.0.0` was bootstrapped manually outside this skill; from then on this skill drives every release.)
+
+### Resume detection (run before requiring a clean tree)
+
+A previous run — or a manual edit — may have already committed the version bump without pushing the tag (e.g. CI on the bump was still running when the prior run ended). Detect that state before assuming a cold start:
+
+```bash
+git fetch --tags origin
+CUR=$(node -p "require('./package.json').version")
+git tag -l "v$CUR"   # empty output = no tag yet for the current version
+```
+
+- **If `v$CUR` does NOT exist** and the working tree is clean: the current version is un-tagged. Find the commit that introduced it (do NOT assume it is `HEAD`):
+
+  ```bash
+  BUMP_SHA=$(git log -1 --format=%H -S"\"version\": \"$CUR\"" -- package.json)
+  ```
+
+  Tell the user the bump for `v$CUR` is already committed (`$BUMP_SHA`) and offer to **RESUME** — this skips Steps 2–6 (bump / changelog / commit) and continues from **Step 7** (CI wait) onward, tagging **`$BUMP_SHA`**, through the same push-tag → publish → GitHub Release path. The resume confirmation stands in for the Step 3 gate. If `$BUMP_SHA` is not the current `HEAD`, later commits landed on top — surface that and let the user choose: tag `$BUMP_SHA` as-is, or abort and cut a fresh bump that includes the newer commits.
+- **If `v$CUR` already exists**: the current version is released. Proceed with a normal cold-start bump (Steps 2–6). Require a **clean working tree** (`git status --porcelain` empty) on this cold-start path.
 
 ## Step 2: Determine Next Version
 
@@ -87,7 +116,7 @@ Apply the rules based on the optional argument:
 
 > The normal flow is: cut one or more `…-next.N` prereleases (which publish to the `next` dist-tag for testing), then run `/l-make-release stable` to promote the same version to a stable `latest` release.
 
-## Step 3: Analyze Changes and Propose
+## Step 3: Analyze Changes and Propose — THE GATE
 
 Find the latest version tag and analyze commits since it:
 
@@ -122,7 +151,7 @@ Other Changes:
 - description (hash)
 ```
 
-Only show sections that have entries. **Wait for explicit user confirmation before proceeding to Step 4.**
+Only show sections that have entries. **Wait for explicit user confirmation before proceeding to Step 4.** Confirming here authorizes the full flow through `pnpm publish` and the GitHub Release — the only thing that can stop it afterward is a build/test failure (Step 5) or a publish-workflow failure (Step 9).
 
 ## Step 4: Bump + Bilingual Changelog
 
@@ -137,7 +166,7 @@ Read `doc/src/content/CLAUDE.md` first — it defines the bilingual + translatio
 - `doc/src/content/docs/changelog/v<version>.mdx` (English)
 - `doc/src/content/docs-ja/changelog/v<version>.mdx` (Japanese)
 
-Match the format of the existing entries (read `doc/src/content/docs/changelog/v0.2.0.mdx` and its JA counterpart). Frontmatter:
+Match the format of the existing entries (read `doc/src/content/docs/changelog/v1.1.0-next.1.mdx` and its JA counterpart). Frontmatter:
 
 ```mdx
 ---
@@ -171,7 +200,7 @@ Also confirm the new changelog passes the Astro content schema:
 pnpm build:doc
 ```
 
-If anything fails, stop and tell the user. Do not proceed.
+If anything fails, stop and tell the user. Do not commit. This is the last halt point before anything reaches the remote.
 
 ## Step 6: Atomic Commit + Push
 
@@ -196,34 +225,69 @@ Delegate CI polling to `/watch-ci` — do NOT reimplement polling:
 Skill(skill="watch-ci", args="--branch main --commit <BUMP_SHA>")
 ```
 
-If CI fails, fix the issue, commit the fix, push, and re-invoke `/watch-ci` before proceeding.
+If `/watch-ci` is unavailable in the running session, fall back to a direct poll:
 
-## Step 8: Notify + STOP (do NOT push the tag)
-
-Print the message below **verbatim** (substitute the actual version for `<version>`). Then STOP — do not push the tag, do not publish.
-
+```bash
+gh run watch "$(gh run list --branch main --commit <BUMP_SHA> --limit 1 --json databaseId -q '.[0].databaseId')" --exit-status
 ```
-============================================================
-Release bump committed and pushed to main.
-CI on the bump commit: PASSED.
 
-NEXT STEP — push the tag to trigger the npm publish workflow:
+If CI fails, fix the issue, commit the fix, push, and re-watch before proceeding. Do not advance to the tag push until CI on the bump commit is green.
 
-  git tag v<version> && git push origin v<version>
+## Step 8: Push the Tag (triggers the publish)
 
-That fires .github/workflows/publish.yml, which builds, tests, and
-publishes @takazudo/zudo-design-token-lint to npm.
+Mint the tag on the bump commit and push it — the push is what fires `.github/workflows/publish.yml`:
 
-Dist-tag (handled automatically by the workflow):
-  - prerelease (…-next.N) → published under the "next" dist-tag
-  - stable (X.Y.Z)        → published under "latest"
-
-After pushing the tag, watch the run and verify:
-
-  gh run watch
-  npm view @takazudo/zudo-design-token-lint version dist-tags
-============================================================
+```bash
+git tag "v<version>" <BUMP_SHA>
+git push origin "v<version>"
 ```
+
+The `v*.*.*` tag push triggers the publish workflow. Do NOT ask "push the tag now?" — the Step 3 confirmation already authorized this.
+
+## Step 9: Watch the Publish Workflow
+
+Find the run `publish.yml` started for this tag (allow a few seconds for it to register), then watch it to completion:
+
+```bash
+PUBLISH_RUN=$(gh run list --workflow publish.yml --limit 5 \
+  --json databaseId,headBranch -q '[.[] | select(.headBranch=="v<version>")][0].databaseId')
+# Fallback if the tag-ref filter returns nothing: the most recent publish.yml run
+[ -z "$PUBLISH_RUN" ] && PUBLISH_RUN=$(gh run list --workflow publish.yml --limit 1 --json databaseId -q '.[0].databaseId')
+gh run watch "$PUBLISH_RUN" --exit-status
+```
+
+If the publish workflow fails, surface the failing logs (`gh run view "$PUBLISH_RUN" --log-failed`) and **stop** — the npm publish did not complete. Do NOT create the GitHub Release. See [Failure Recovery](#failure-recovery) (the version cannot be re-published; a code fix needs a new version).
+
+## Step 10: Create the GitHub Release
+
+The publish succeeded — record it on GitHub. Extract the changelog body (everything after the frontmatter) as the release notes. The tag already exists on the remote, so use `--verify-tag`. Add `--prerelease` for a `-next.` / `-beta.` / `-rc.` version:
+
+```bash
+awk 'f; /^---$/{c++; if(c==2) f=1}' doc/src/content/docs/changelog/v<version>.mdx > /tmp/zdtl-release-notes.md
+PRERELEASE_FLAG=$([[ "<version>" =~ -next\.|-beta\.|-rc\. ]] && echo "--prerelease" || echo "")
+gh release create "v<version>" --verify-tag --title "v<version>" $PRERELEASE_FLAG \
+  --notes-file /tmp/zdtl-release-notes.md
+```
+
+## Step 11: Verify dist-tag + Report, then STOP
+
+Confirm the publish landed under the expected dist-tag:
+
+```bash
+npm view "@takazudo/zudo-design-token-lint@<version>" version
+npm dist-tag ls @takazudo/zudo-design-token-lint
+```
+
+The version should appear under **`next`** for a prerelease, **`latest`** for a stable release.
+
+**Warn-only dist-tag check**: if a **prerelease** version is showing under `latest` (or `latest` points at an older prerelease — a known artifact of the very first publish), surface a warning. Do NOT auto-fix — moving a dist-tag is a registry-level mutation that deserves a human:
+
+```bash
+npm dist-tag rm @takazudo/zudo-design-token-lint latest        # remove a stray prerelease from latest
+# (or repoint once a real stable ships: npm dist-tag add @takazudo/zudo-design-token-lint <stable> latest)
+```
+
+Print a final report — published version + dist-tag, the npm package URL (`https://www.npmjs.com/package/@takazudo/zudo-design-token-lint`), the publish workflow run, and the GitHub Release URL — then **STOP**.
 
 ## Dist-tag policy
 
@@ -242,9 +306,13 @@ npm dist-tag add @takazudo/zudo-design-token-lint@<newest-prerelease> next
 
 ## Cancelling a release
 
-Use this when the user runs `/l-make-release cancel` (or "abort/cancel the release"), or a problem is found after the bump commit but **before** the tag was pushed.
+Use this when the user runs `/l-make-release cancel` (or "abort/cancel the release"), or a problem is found mid-release. What you can undo depends on **how far the flow got** — the tag push (Step 8) is the irreversible boundary.
 
-1. **Delete a local, unpushed tag** if one was created by mistake (`git tag -d v<version>`). If the tag was already pushed, do NOT delete it remotely — a pushed `v*` tag may have already triggered a publish; treat it as live.
+### The tag has NOT been pushed yet (before Step 8)
+
+Nothing is published — this is fully recoverable.
+
+1. **Delete a local, unpushed tag** if one was minted by mistake (`git tag -d v<version>`).
 2. **Decide whether to undo the bump commit.** Check where it sits:
 
    ```bash
@@ -260,9 +328,16 @@ Use this when the user runs `/l-make-release cancel` (or "abort/cancel the relea
 
    - **`>0` — the bump is buried under later commits**: do NOT revert or rewrite history. The stale version number is harmless — the next release simply bumps from it and supersedes the abandoned version. Leave it.
 
+### The tag HAS been pushed (Step 8 done)
+
+A pushed `v*` tag may have already triggered — or completed — a publish. **Treat the version as live.** Do NOT delete the remote tag and do NOT attempt to re-publish that version (npm forbids it). If the publish failed, recover by cutting a **new** version — see [Failure Recovery](#failure-recovery). If it succeeded but you want to retract it, that is a manual `npm unpublish` / `npm deprecate` decision for the user, outside this skill.
+
 ## Failure Recovery
 
-- **Build/test failure (Step 5)** — stop and report. Do not commit. Fix and re-run.
-- **CI fails on the bump commit (Step 7)** — fix, commit, push, re-invoke `/watch-ci`. Do not advance to Step 8 until CI is green.
+- **Build/test failure (Step 5)** — stop and report. Do not commit. Fix and re-run. Nothing reached the remote.
+- **CI fails on the bump commit (Step 7)** — fix, commit, push, re-watch CI. Do not push the tag until CI is green.
 - **Wrong version proposed** — the Step 3 confirmation gate is where this is caught. If a wrong version was already committed but the tag has NOT been pushed, use [Cancelling a release](#cancelling-a-release) to revert and re-run.
-- **npm publish failed in CI with an OTP / `EOTP` / 2FA error** — `NPM_TOKEN` is not an Automation-type token. Regenerate it as an **Automation** token (or a granular token with 2FA bypass) at npmjs.com and update the repo secret, then re-push the tag (delete + re-push, or use the workflow's `workflow_dispatch`).
+- **Publish workflow fails after the tag was pushed (Step 9)** — the tag exists on the remote but the npm publish did not complete. Inspect `gh run view "$PUBLISH_RUN" --log-failed`.
+  - If the failure is **transient** (registry hiccup, runner eviction), re-run the same workflow: `gh run rerun "$PUBLISH_RUN"`. The version was never published, so a clean re-run can still succeed under the same tag.
+  - If the fix needs a **code change**, the tag must move to a new commit — npm will not accept the same version twice. Delete and re-cut: `git push origin :refs/tags/v<version>` (delete the remote tag), `git tag -d v<version>` (delete locally), fix the code, then re-run `/l-make-release` (resume detection will pick the un-tagged bump up, or cut a fresh version). A version that already published successfully can never be re-published — cut a new one.
+- **npm publish failed in CI with an OTP / `EOTP` / 2FA error** — `NPM_TOKEN` is not an Automation-type token. Scoped publish (`@takazudo/*`) requires 2FA, and only an Automation (or 2FA-bypassing granular) token can publish unattended in CI. Regenerate it as an **Automation** token at npmjs.com, update the repo secret (`gh secret set NPM_TOKEN`), then recover per the "code change" path above (delete + re-cut the tag, or use the workflow's `workflow_dispatch`).


### PR DESCRIPTION
## Summary

Rewrites the project-local `/l-make-release` skill (`.claude/skills/l-make-release/SKILL.md`) so a **single invocation drives the release all the way to npm publish**, instead of stopping right before the tag push and leaving the user to `git push origin v<version>` manually.

Modeled on the sibling project **zdtp**'s release skill — the structural twin: a single npm package whose `v*` tag push triggers the publish workflow. The one human gate is the **Step 3 version-bump proposal**; confirming it authorizes the whole flow through publish + GitHub Release (no second "push the tag now?" prompt).

New end-to-end flow:

```
confirm bump (Step 3) → bump + bilingual changelog → commit + push main → CI green
  → push v<version> tag → publish.yml (build + test + pnpm publish) → watch run
  → create GitHub Release → verify dist-tag → STOP
```

## Changes

- **`.claude/skills/l-make-release/SKILL.md`** rewritten to the auto-publish model:
  - Frontmatter `description` now describes the end-to-end behavior and the single Step 3 gate.
  - New **Boundaries** + **How publishing works** diagram: the skill now pushes the tag, triggers publish, and creates the GitHub Release after publish succeeds.
  - New **Step 8** (mint + push the `v*` tag), **Step 9** (watch `publish.yml`), **Step 10** (create the GitHub Release from the EN changelog body), **Step 11** (verify dist-tag + report).
  - **Cancelling a release** and **Failure Recovery** updated for the post-tag-push states (npm can't re-publish a version → cut a new one).
  - Added a **resume / partial-state** note for an already-committed-but-untagged bump.

### Kept (zdtl-specific — not copied from zdtp)

- Root `package.json` as the version source-of-truth (single package; `doc/` Astro site is not published).
- The **bilingual** (EN + JA) doc-site changelog under `doc/src/content/docs{,-ja}/changelog/`, with the count-down `sidebar_position` convention.
- `pnpm build && pnpm test` + `pnpm build:doc` validation; atomic single-commit bump; `/watch-ci` delegation for CI on the bump commit.
- The 1.x prerelease (`-next.N`) → `stable` promotion version strategy.

### Review hardening (codex)

- **Step 9**: match the publish run deterministically by the tagged commit SHA (`headSha`) with a retry loop, and fail rather than fall back to the most-recent `publish.yml` run — prevents watching an older successful release and creating the Release prematurely.
- **Step 7/8**: refresh `BUMP_SHA` to the green commit after a CI-fix so the tag points at the commit whose CI actually passed.
- **Resume detection**: STOP on a dirty working tree when the current version is un-tagged.

## Test Plan

- Documentation/skill markdown only (under `.claude/`, excluded from prettier and CI build/test) — no source/test/build impact.
- Embedded commands sanity-checked: the awk frontmatter-strip produces the changelog body cleanly against an existing entry; `headSha`-based run matching and the `-S` pickaxe `BUMP_SHA` lookup are deterministic; internal anchors (`#failure-recovery`, `#cancelling-a-release`) resolve.
- Cross-checked against this repo's real `.github/workflows/publish.yml` (triggers on `v*.*.*`, derives dist-tag from the version string), root `package.json`, and the bilingual changelog dirs.