### PR TITLE
feat(doc): add page-loading overlay + indicator styling

### DIFF
--- a/doc/pages/lib/_body-end-islands.tsx
+++ b/doc/pages/lib/_body-end-islands.tsx
@@ -159,9 +159,10 @@ export function BodyEndIslands({
 
   return (
     <>
-      {/* Pure SSR — no Island wrap. The component emits its overlay div,
-          inline styles, and a small inline script that self-wires
-          zfb:before-preparation / zfb:after-swap listeners at runtime. */}
+      {/* Pure SSR — no Island wrap. The component emits its overlay div and a
+          small inline script that self-wires zfb:before-preparation /
+          zfb:after-swap listeners at runtime. Its CSS lives in
+          src/styles/global.css (the component emits no inline <style>). */}
       <PageLoadingOverlay />
       {clientRouterBootstrap}
       {aiAssistant}

--- a/doc/src/styles/global.css
+++ b/doc/src/styles/global.css
@@ -976,7 +976,11 @@ button[data-zd-nav-pending] {
 .page-loading-spinner {
   width: 48px;
   height: 48px;
-  border: 5px solid var(--color-fg, #fff);
+  /* The scrim is always dark (--color-overlay is black), so the spinner needs a
+     light stroke in BOTH color schemes. --color-image-overlay-fg is the token
+     for foreground content shown on a dark overlay (light in light + dark
+     schemes) — using --color-fg would go dark-on-dark in the light scheme. */
+  border: 5px solid var(--color-image-overlay-fg, #fff);
   border-bottom-color: transparent;
   border-radius: 50%;
   display: inline-block;
@@ -1004,7 +1008,7 @@ button[data-zd-nav-pending] {
 @media (prefers-reduced-motion: reduce) {
   .page-loading-spinner {
     animation: none;
-    border-bottom-color: var(--color-fg, #fff);
+    border-bottom-color: var(--color-image-overlay-fg, #fff);
     opacity: 0.5;
   }
 }

--- a/doc/src/styles/global.css
+++ b/doc/src/styles/global.css
@@ -936,3 +936,75 @@ dialog.zd-enlarge-dialog::backdrop {
 .diff-line-empty {
   background-color: color-mix(in oklch, var(--color-muted) 8%, transparent);
 }
+
+/* ========================================
+ * Page-loading overlay + spinner
+ * ----------------------------------------
+ * Styles for the PageLoadingOverlay component (mounted in
+ * pages/lib/_body-end-islands.tsx). The component renders only the overlay
+ * markup and a small self-wiring inline <script> — it intentionally emits NO
+ * inline <style>, because a <style> element inside <body> violates the HTML5
+ * content model and fails html-validate. So its CSS has to live here, in the
+ * host stylesheet. The overlay's inline script toggles `data-visible` on
+ * navigation (zfb:before-preparation → show, zfb:after-swap → hide) and stamps
+ * `data-zd-nav-pending` on the link/button being navigated from.
+ * ======================================== */
+.page-loading-overlay {
+  position: fixed;
+  inset: 0;
+  /* Modal tier: a full-screen page-load overlay and an active pointer-drag
+     (the --z-index-drag ghost) never coexist, so modal is high enough. */
+  z-index: var(--z-index-modal);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in oklch, var(--color-overlay) 60%, transparent);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 150ms ease-out;
+}
+
+.page-loading-overlay[data-visible] {
+  opacity: 1;
+}
+
+a[data-zd-nav-pending],
+button[data-zd-nav-pending] {
+  color: var(--color-accent);
+}
+
+.page-loading-spinner {
+  width: 48px;
+  height: 48px;
+  border: 5px solid var(--color-fg, #fff);
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: page-loading-spin 1s linear infinite;
+}
+
+@media (min-width: 1024px) {
+  .page-loading-spinner {
+    width: 64px;
+    height: 64px;
+    border-width: 6px;
+  }
+}
+
+@keyframes page-loading-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page-loading-spinner {
+    animation: none;
+    border-bottom-color: var(--color-fg, #fff);
+    opacity: 0.5;
+  }
+}


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-lint/issues/92

---

## Summary

The doc site already mounts the package-provided `PageLoadingOverlay` component (in `doc/pages/lib/_body-end-islands.tsx`) and has the SPA client-router wired, but the overlay had **no CSS**, so it rendered invisibly during navigation. As of the installed `@takazudo/zudo-doc` version the component emits no inline `<style>` (a `<style>` inside `<body>` fails html-validate), so the overlay's styling has to live in the host stylesheet.

This adds the missing overlay + spinner + pending-link-indicator CSS to `doc/src/styles/global.css`, reusing existing design tokens — no new tokens and no new z-index tier.

## Changes

- **`doc/src/styles/global.css`** — add the `.page-loading-overlay`, `[data-visible]`, `.page-loading-spinner` (base + ≥1024px responsive + reduced-motion), `a/button[data-zd-nav-pending]`, and `@keyframes page-loading-spin` rules.
    - Overlay: `position: fixed` full-viewport, `z-index: var(--z-index-modal)`, translucent `--color-overlay` scrim, fade via `opacity` + `transition`.
    - Spinner stroke uses `--color-image-overlay-fg` (light in both color schemes) so it contrasts against the always-dark scrim — addressing a code-review contrast finding (`--color-fg` would be dark-on-dark in the light scheme).
    - Pending-link indicator tints the navigating link/button to `--color-accent`.
- **`doc/pages/lib/_body-end-islands.tsx`** — correct the stale comment: the component no longer emits inline styles; its CSS lives in `global.css`.

## Test Plan

- `pnpm check:doc` (type check), `pnpm lint` (prettier), `pnpm build:doc`, and html-validate all pass.
- 15/15 deterministic computed-style assertions (headless Chromium): overlay geometry/z-index/opacity toggle, spinner size (48/64px) + animation + light stroke, reduced-motion disables the spin, pending-link accent tint.
- Visually confirmed the overlay + spinner render correctly in both color schemes.

## Notes

- The overlay intentionally keeps `pointer-events: none` even when visible (click-through), matching the reference implementation's deliberate, e2e-tested behavior.