### PR TITLE
fix(doc): sync playground lint-browser mirror with fixed engine logic

### DIFF
--- a/doc/src/lib/lint-browser.ts
+++ b/doc/src/lib/lint-browser.ts
@@ -184,12 +184,21 @@ export function extractClasses(content: string): ExtractedClass[] {
   const doubleQuoteAttr = /(?:className|class)\s*=\s*"([^"]+)"/g;
   const singleQuoteAttr = /(?:className|class)\s*=\s*'([^']+)'/g;
   const singleQuoteBrace = /(?:className|class)\s*=\s*\{\s*'([^']+)'\s*\}/g;
+  const doubleQuoteBrace = /(?:className|class)\s*=\s*\{\s*"([^"]+)"\s*\}/g;
   const templateLiteral = /(?:className|class)\s*=\s*\{\s*`([^`]+)`\s*\}/g;
-  const classListPattern = /class:list\s*=\s*\{\s*\[([^\]]+)\]\s*\}/g;
-  const utilFnPattern =
-    /(?:cn|clsx|classNames|twMerge)\s*\(\s*([^)]+)\)/g;
 
-  for (let i = 0; i < lines.length; i++) {
+  // class:list={[...]} — matches only up to the opening '[' — the array
+  // contents are scanned separately via scanBalancedDelimited so the array
+  // can span multiple lines.
+  const classListStart = /class:list\s*=\s*\{\s*\[/g;
+
+  // Utility function call-start pattern — matches only the function name +
+  // opening paren — the args are scanned separately via
+  // scanBalancedDelimited so calls can span multiple lines. Word-boundary
+  // guard avoids matching a substring of a longer identifier (e.g. "xcn(").
+  const utilFnStart = /(?<![\w$])(?:cn|clsx|classNames|twMerge)\s*\(/g;
+
+  lineLoop: for (let i = 0; i < lines.length; i++) {
     if (ignoredLines.has(i)) continue;
 
     const line = lines[i];
@@ -204,24 +213,220 @@ export function extractClasses(content: string): ExtractedClass[] {
     for (const match of line.matchAll(singleQuoteBrace)) {
       addClasses(results, match[1], lineNum);
     }
+    for (const match of line.matchAll(doubleQuoteBrace)) {
+      addClasses(results, match[1], lineNum);
+    }
     for (const match of line.matchAll(templateLiteral)) {
       addClasses(results, match[1], lineNum);
     }
-    for (const match of line.matchAll(classListPattern)) {
-      const arrayContent = match[1];
-      for (const strMatch of arrayContent.matchAll(/['"]([^'"]+)['"]/g)) {
-        addClasses(results, strMatch[1], lineNum);
+
+    // class:list={[...]} — accumulate across lines until brackets balance
+    // (same 50-line cap as utility function calls).
+    classListStart.lastIndex = 0;
+    let clMatch: RegExpExecArray | null;
+    while ((clMatch = classListStart.exec(line)) !== null) {
+      const startCol = classListStart.lastIndex; // just past the opening '['
+      const arr = scanBalancedDelimited(lines, i, startCol, "[", "]");
+      extractFromClassListArray(results, arr.content, i, ignoredLines);
+
+      if (arr.endLine !== i) {
+        // Array spanned multiple lines. Blank out the consumed prefix of the
+        // closing line (preserving column positions) and reprocess that
+        // line, so source after the closing ']' is still scanned.
+        lines[arr.endLine] =
+          " ".repeat(arr.endCol) + lines[arr.endLine].slice(arr.endCol);
+        i = arr.endLine - 1;
+        continue lineLoop;
       }
+      classListStart.lastIndex = arr.endCol;
     }
-    for (const match of line.matchAll(utilFnPattern)) {
-      const argsContent = match[1];
-      for (const strMatch of argsContent.matchAll(/['"]([^'"]+)['"]/g)) {
-        addClasses(results, strMatch[1], lineNum);
+
+    // cn(...) / clsx(...) / classNames(...) / twMerge(...) — accumulate
+    // arguments across lines until parens balance.
+    utilFnStart.lastIndex = 0;
+    let fnMatch: RegExpExecArray | null;
+    while ((fnMatch = utilFnStart.exec(line)) !== null) {
+      const startCol = utilFnStart.lastIndex; // just past the opening '('
+      const call = scanBalancedDelimited(lines, i, startCol, "(", ")");
+      extractFromCallArgs(results, call.content, i, ignoredLines);
+
+      if (call.endLine !== i) {
+        // Call spanned multiple lines. Blank out the consumed prefix of the
+        // closing line (preserving column positions) and reprocess that
+        // line, so source after the closing ')' is still scanned.
+        lines[call.endLine] =
+          " ".repeat(call.endCol) + lines[call.endLine].slice(call.endCol);
+        i = call.endLine - 1;
+        continue lineLoop;
       }
+      utilFnStart.lastIndex = call.endCol;
     }
   }
 
   return results;
+}
+
+interface BalancedScan {
+  /** Joined text between the opening and closing delimiter (exclusive). */
+  content: string;
+  /** Index (0-based) of the line containing the closing delimiter, or the last line scanned. */
+  endLine: number;
+  /** Column just past the closing delimiter on `endLine` (only meaningful when balanced). */
+  endCol: number;
+}
+
+/**
+ * Scan forward from just after an opening delimiter (`(` for utility
+ * function calls, `[` for `class:list` arrays), tracking delimiter depth
+ * while skipping over string/template-literal contents — so a closing
+ * delimiter or a nested opening one inside a string literal never affects
+ * balance. Crosses line boundaries up to a 50-line safety cap, returning
+ * whatever was accumulated if the cap is hit.
+ */
+function scanBalancedDelimited(
+  lines: string[],
+  startLine: number,
+  startCol: number,
+  openChar: string,
+  closeChar: string,
+): BalancedScan {
+  const maxLines = 50;
+  let depth = 1;
+  let content = "";
+  let quote: string | null = null;
+  let line = startLine;
+  let col = startCol;
+  let linesConsumed = 0;
+
+  while (line < lines.length) {
+    const text = lines[line];
+    while (col < text.length) {
+      const ch = text[col];
+
+      if (quote) {
+        if (ch === "\\" && col + 1 < text.length) {
+          content += ch + text[col + 1];
+          col += 2;
+          continue;
+        }
+        if (ch === quote) quote = null;
+        content += ch;
+        col++;
+        continue;
+      }
+
+      if (ch === '"' || ch === "'" || ch === "`") {
+        quote = ch;
+        content += ch;
+        col++;
+        continue;
+      }
+
+      if (ch === openChar) {
+        depth++;
+        content += ch;
+        col++;
+        continue;
+      }
+
+      if (ch === closeChar) {
+        depth--;
+        col++;
+        if (depth === 0) {
+          return { content, endLine: line, endCol: col };
+        }
+        content += ch;
+        continue;
+      }
+
+      content += ch;
+      col++;
+    }
+
+    if (line + 1 >= lines.length || linesConsumed >= maxLines) {
+      return { content, endLine: line, endCol: col };
+    }
+    line++;
+    col = 0;
+    linesConsumed++;
+    content += "\n";
+  }
+
+  return { content, endLine: Math.max(line - 1, startLine), endCol: col };
+}
+
+/**
+ * Return the 0-based character offset of every `\n` in `text`, in ascending
+ * order. Used to map a match's character index in accumulated multiline
+ * content back to the source line it actually came from.
+ */
+function collectNewlineOffsets(text: string): number[] {
+  const offsets: number[] = [];
+  for (let idx = 0; idx < text.length; idx++) {
+    if (text.charCodeAt(idx) === 10) offsets.push(idx);
+  }
+  return offsets;
+}
+
+/**
+ * Extract string-literal and template-literal class tokens from a utility
+ * function's joined argument text. Each match is attributed to its actual
+ * source line — `startLine0` (0-based) plus the number of newlines
+ * accumulated before the match — not the line the call opened on, so a
+ * design-token-lint-ignore comment on an inner argument line suppresses
+ * only that line's classes. Template-literal tokens containing `${...}`
+ * fall through untouched — they don't match any lint rule pattern.
+ */
+function extractFromCallArgs(
+  results: ExtractedClass[],
+  argsText: string,
+  startLine0: number,
+  ignoredLines: Set<number>,
+): void {
+  const newlineOffsets = collectNewlineOffsets(argsText);
+  let cursor = 0;
+  for (const match of argsText.matchAll(/'([^']*)'|"([^"]*)"|`([^`]*)`/g)) {
+    const value = match[1] ?? match[2] ?? match[3] ?? "";
+    const matchIndex = match.index ?? 0;
+    while (
+      cursor < newlineOffsets.length &&
+      newlineOffsets[cursor] < matchIndex
+    ) {
+      cursor++;
+    }
+    const actualLine0 = startLine0 + cursor;
+    if (ignoredLines.has(actualLine0)) continue;
+    addClasses(results, value, actualLine0 + 1);
+  }
+}
+
+/**
+ * Extract single/double-quoted string literals from a `class:list` array's
+ * joined content (object-key form like `{ "p-4": true }` is included, since
+ * the key itself is a quoted string literal). Each match is attributed to
+ * its actual source line — see extractFromCallArgs for why, and for the
+ * ignoredLines semantics applied per inner line.
+ */
+function extractFromClassListArray(
+  results: ExtractedClass[],
+  arrayContent: string,
+  startLine0: number,
+  ignoredLines: Set<number>,
+): void {
+  const newlineOffsets = collectNewlineOffsets(arrayContent);
+  let cursor = 0;
+  for (const match of arrayContent.matchAll(/['"]([^'"]+)['"]/g)) {
+    const matchIndex = match.index ?? 0;
+    while (
+      cursor < newlineOffsets.length &&
+      newlineOffsets[cursor] < matchIndex
+    ) {
+      cursor++;
+    }
+    const actualLine0 = startLine0 + cursor;
+    if (ignoredLines.has(actualLine0)) continue;
+    addClasses(results, match[1], actualLine0 + 1);
+  }
 }
 
 // ── Rule matching (from src/rules.ts) ──────────────────────────────
@@ -278,8 +483,14 @@ export function checkClassWithConfig(
   const lastColon = className.lastIndexOf(":");
   let stripped = lastColon >= 0 ? className.slice(lastColon + 1) : className;
 
+  // Strip important modifier — leading form is Tailwind v3 (!p-4, sm:!p-4),
+  // trailing form is Tailwind v4 (p-4!, sm:p-4!). Both must be stripped
+  // before the negative/opacity handling below.
   if (stripped.startsWith("!")) {
     stripped = stripped.slice(1);
+  }
+  if (stripped.endsWith("!")) {
+    stripped = stripped.slice(0, -1);
   }
 
   const isNegative = stripped.startsWith("-");
@@ -293,7 +504,10 @@ export function checkClassWithConfig(
     return null;
   }
 
-  if (config.allowed.has(withoutOpacity)) {
+  // Match against the normalized form AND the original className verbatim,
+  // so exact-match entries like "-mt-4", "hover:p-2", or "bg-red-500/50"
+  // (copied straight from a violation message) actually take effect.
+  if (config.allowed.has(withoutOpacity) || config.allowed.has(className)) {
     return null;
   }
 


### PR DESCRIPTION
Closes #107

## Problem

`doc/src/lib/lint-browser.ts` is a hand-maintained browser-safe mirror of `src/config.ts` + `src/extractor.ts` + `src/rules.ts` (used by the docs playground so linting can run without Node.js APIs). It hadn't been updated with the fixes/features that landed in Improvement Sweep #106, so the interactive playground produced results inconsistent with the published npm package.

Verified how the mirror is consumed: `doc/src/components/playground.tsx` feeds arbitrary user-typed code (a free-form textarea, not just a list of class names) through `compileConfig` + `lintContent`, which calls the mirrored `extractClasses` + `checkClassWithConfig`. So the mirror's scope genuinely covers the full pipeline — config compilation, class extraction, and rule matching — not just rule-matching.

## Synced (verified against `src/rules.ts` / `src/extractor.ts` as source of truth)

- **`checkClassWithConfig`** (issue #107's core ask, from #96):
  - Strip a trailing `!` (Tailwind v4 important modifier, e.g. `p-4!`, `sm:p-4!`) in addition to the existing leading `!` (v3) strip.
  - Match the `allowed` set against both the original `className` and the normalized form, so verbatim entries like `-mt-4`, `hover:p-2`, `bg-red-500/50` take effect.
- **`extractClasses`**:
  - Added the `className={"..."}` / `class={"..."}` brace-double-quote form (was missing entirely).
  - Added a word-boundary guard (`(?<![\w$])`) on `cn`/`clsx`/`classNames`/`twMerge` call detection, so a longer identifier ending in one of those names (e.g. `xcn(`) is no longer misdetected as a call.
  - Replaced the naive single-line, unbalanced regex scan for `cn()`/`clsx()`/`classNames()`/`twMerge()` calls and `class:list={[...]}` arrays with a balanced-delimiter scanner (`scanBalancedDelimited`) that tracks paren/bracket depth across up to 50 lines, skips over quoted/template-literal contents so a `)`/`]` inside a string doesn't break balance, and reprocesses the remainder of a closing line after a multiline construct ends.
  - Each class extracted from inside a multiline call/array is now attributed to its **true source line** (via newline-offset counting), not the line the call opened on — and a `design-token-lint-ignore` comment on an inner line now correctly suppresses only that line's classes.
  - `cn()`/`clsx()` call arguments now also recognize backtick template-literal string args (previously only single/double-quoted args were extracted).

## Verification

- `cd doc && pnpm check` (tsc) — green.
- `cd doc && pnpm build` (zfb build) — green, 47 pages built.
- No existing tests cover `lint-browser.ts` or the playground component in `doc/`; wrote and ran an ad-hoc smoke script (esbuild-bundled, not committed) exercising every synced behavior above against the new code — all passed, including a full-pipeline `lintContent` check.
- Root `pnpm test` — untouched, 365 tests passed (8 files).

## Deliberately out of scope (and why)

- **6 new default color rules** (`border-s-{color}-{shade}`, `border-e-{color}-{shade}`, `ring-offset-{color}-{shade}`, `inset-ring-{color}-{shade}`, `inset-shadow-{color}-{shade}`, `text-shadow-{color}-{shade}`) added to `src/config.ts`'s `DEFAULT_CONFIG.prohibited`. `lint-browser.ts` has no `DEFAULT_CONFIG` at all — the playground ships its own small, deliberately curated demo config directly in `playground.tsx`, unrelated to the package's built-in defaults — and the generic `{color}-{shade}` pattern-compilation logic that `lint-browser.ts` *does* mirror (`compilePattern`) is unchanged by this sweep. Nothing to sync.
- **Word-boundary guard on attribute names** (`(?<![\w-])` on `className`/`class` matching) — this predates Improvement Sweep #106 (already present in `src/extractor.ts` before the sweep started) and was never mirrored into `lint-browser.ts`, even before this issue. It's a separate, older divergence, not something the engine "just gained" — left untouched to keep this fix scoped to #107. Worth a follow-up issue if it's actually a real playground pain point.
- **Unbalanced multiline `className="..."` attribute accumulation** (attribute value with no closing quote on the same line) — also predates the sweep and was never mirrored. Same reasoning as above.
- **`compilePattern` placeholder validation and literal-segment regex escaping** (`validatePlaceholders`, `expandValuePart`/`escapeRegExp`) added to `src/config.ts` in this sweep — not part of issue #107's described behavior list, and orthogonal to it (it hardens custom `prohibited` pattern strings against typos/regex-metacharacter bugs, not a linting-result inconsistency). Left out to keep this PR focused; the playground would silently produce a different-but-not-yet-observed edge case only if a user types a malformed custom pattern string.
- **`semanticPrefixes` / `classAttributes` / `classFunctions` configurability** on `CompiledConfig` — predates the sweep, and `playground.tsx`'s `parseLintConfig` has no UI/parsing surface for these fields (only `prohibited`/`allowed`/`ignore`/`suggestionSuffix`). Wiring them in now would be grafting in engine surface the playground never exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)