### PR TITLE
fix: backslash-escape awareness in cn()/class:list literal extraction (#139)

### DIFF
--- a/src/extractor.test.ts
+++ b/src/extractor.test.ts
@@ -841,21 +841,72 @@ const b = cn(
 
   describe('backslash-escaped quotes inside call arguments (scanBalancedDelimited)', () => {
     it('a backslash-escaped quote does not end the call early, so a later sibling argument is still reached', () => {
-      // scanBalancedDelimited's backslash handling (extractor.ts:277-282)
-      // keeps the whole first argument inside one quoted span despite the
-      // embedded escaped quotes, so the call's true closing paren is found
-      // correctly and "m-8" is reached at all. extractFromCallArgs' own
-      // token regex has no escape awareness, though, so the escaped-quote
-      // argument itself is mangled into fragments rather than one clean
-      // string — that quirk is pinned exactly here rather than hidden behind
-      // a looser assertion.
+      // scanBalancedDelimited's backslash handling keeps the whole first
+      // argument inside one quoted span despite the embedded escaped quotes,
+      // so the call's true closing paren is found correctly and "m-8" is
+      // reached at all. Originally (#133) extractFromCallArgs' own
+      // token regex had no escape awareness, so the escaped-quote argument
+      // was mangled into fragments (`say`, `\`, `p-4`) rather than one clean
+      // string — that quirk was deliberately pinned as out of scope for that
+      // task. #139 made scanQuotedLiterals (the token scanner shared by
+      // extractFromCallArgs/extractFromClassListArray) backslash-escape
+      // aware too, so the whole first argument is now recognized as ONE
+      // literal token (escape sequences left raw/unresolved, matching
+      // scanBalancedDelimited's own style) — this re-pins the corrected
+      // output. The key invariant #133 actually cared about — that "p-4" and
+      // "m-8" are never lost — still holds, and holds more cleanly now.
       const content = `const cls = cn("say \\"hi\\" p-4", "m-8");`;
       const result = extractClasses(content);
       expect(result).toEqual([
         { className: 'say', line: 1 },
-        { className: '\\', line: 1 },
+        { className: '\\"hi\\"', line: 1 },
         { className: 'p-4', line: 1 },
         { className: 'm-8', line: 1 },
+      ]);
+    });
+  });
+
+  describe('backslash-escaped quotes no longer drop a sibling violation (#139)', () => {
+    it('a sibling violation after an escaped single-quoted argument is still extracted', () => {
+      // Before #139, the naive per-token regex closed the first string on the
+      // escaped quote itself, desyncing the remaining scan so the trailing
+      // unpaired quote around "p-4" never found a partner and the violation
+      // was silently dropped entirely (not just mangled). This is the exact
+      // repro from the issue.
+      const content = `const cls = cn('it\\'s', 'p-4');`;
+      const result = extractClasses(content);
+      expect(result.some((r) => r.className === 'p-4')).toBe(true);
+    });
+
+    it('a sibling violation after an escaped double-quoted argument is still extracted', () => {
+      const content = `const cls = cn("a\\"b", "p-4");`;
+      const result = extractClasses(content);
+      expect(result.some((r) => r.className === 'p-4')).toBe(true);
+    });
+
+    it('handles escaped quotes in both single- and double-quoted call args, keeping every sibling violation', () => {
+      const content = `const cls = cn('a\\'b', "c\\"d", 'p-4', "m-8");`;
+      const result = extractClasses(content);
+      expect(result.some((r) => r.className === 'p-4')).toBe(true);
+      expect(result.some((r) => r.className === 'm-8')).toBe(true);
+    });
+
+    it('a class:list array argument with an escaped quote does not drop a sibling violation', () => {
+      const content = `<div class:list={["it\\'s", 'p-4']}>`;
+      const result = extractClasses(content);
+      expect(result.some((r) => r.className === 'p-4')).toBe(true);
+    });
+
+    it('a class token containing an escaped quote is extracted verbatim, not silently dropped', () => {
+      // Pins the corrected behavior: the escaped-quote token itself is
+      // extracted as one raw (still-escaped) whitespace-delimited chunk
+      // rather than vanishing — the key contract is "nothing is silently
+      // dropped", not any particular unescaping of the token's own text.
+      const content = `const cls = cn('it\\'s', 'p-4');`;
+      const result = extractClasses(content);
+      expect(result).toEqual([
+        { className: "it\\'s", line: 1 },
+        { className: 'p-4', line: 1 },
       ]);
     });
   });

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -730,6 +730,67 @@ function collectNewlineOffsets(text: string): number[] {
   return offsets;
 }
 
+interface QuotedLiteralToken {
+  /** Raw token text between the delimiters, escape sequences left intact. */
+  value: string;
+  /** 0-based offset of the opening quote character in the scanned text. */
+  index: number;
+}
+
+/**
+ * Scan `text` left-to-right for quote-delimited literal tokens, using any
+ * character in `quoteChars` as a delimiter, honoring backslash escapes so an
+ * escaped quote (`\'`, `\"`, `\\`) never prematurely closes the token —
+ * mirrors the escape handling `scanBalancedDelimited` already applies to keep
+ * the surrounding call/array balanced. Before this, `extractFromCallArgs` and
+ * `extractFromClassListArray` found tokens via a plain `'([^']*)'|"..."`
+ * regex with no escape awareness: an escaped quote inside one argument could
+ * desync the token boundaries for every argument after it, in some
+ * quote-parity cases silently dropping a sibling argument's real violation
+ * (#139). A token must open and close with the SAME quote character — a
+ * different quote char encountered inside is just content, matching the old
+ * per-character alternation's behavior (e.g. `["p-4']` never matched as a
+ * literal). An unterminated trailing quote — shouldn't normally happen, since
+ * `scanBalancedDelimited` already validated the surrounding call/array is
+ * balanced — yields no token, same as the old regex requiring both quotes to
+ * be present to match at all.
+ */
+function scanQuotedLiterals(text: string, quoteChars: string): QuotedLiteralToken[] {
+  const tokens: QuotedLiteralToken[] = [];
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+    if (!quoteChars.includes(ch)) {
+      i++;
+      continue;
+    }
+
+    const quote = ch;
+    const start = i;
+    i++;
+    let value = '';
+    let closed = false;
+    while (i < text.length) {
+      const c = text[i];
+      if (c === '\\' && i + 1 < text.length) {
+        value += c + text[i + 1];
+        i += 2;
+        continue;
+      }
+      if (c === quote) {
+        i++;
+        closed = true;
+        break;
+      }
+      value += c;
+      i++;
+    }
+
+    if (closed) tokens.push({ value, index: start });
+  }
+  return tokens;
+}
+
 /**
  * Extract string-literal and template-literal class tokens from a utility
  * function's joined argument text. Each match is attributed to its actual
@@ -749,15 +810,14 @@ function extractFromCallArgs(
 ): void {
   const newlineOffsets = collectNewlineOffsets(argsText);
   let cursor = 0;
-  for (const match of argsText.matchAll(/'([^']*)'|"([^"]*)"|`([^`]*)`/g)) {
-    const value = match[1] ?? match[2] ?? match[3] ?? '';
-    const matchIndex = match.index ?? 0;
+  for (const token of scanQuotedLiterals(argsText, `'"\``)) {
+    const matchIndex = token.index;
     while (cursor < newlineOffsets.length && newlineOffsets[cursor] < matchIndex) {
       cursor++;
     }
     const actualLine0 = startLine0 + cursor;
     if (ignoredLines.has(actualLine0)) continue;
-    addClasses(results, value, actualLine0 + 1);
+    addClasses(results, token.value, actualLine0 + 1);
   }
 }
 
@@ -776,19 +836,14 @@ function extractFromClassListArray(
 ): void {
   const newlineOffsets = collectNewlineOffsets(arrayContent);
   let cursor = 0;
-  // Paired-quote alternation (mirrors extractFromCallArgs) — a token opened
-  // with one quote character must close with the SAME character, so a
-  // mismatched pair like `["p-4']` (opens with ", closes with ') is never
-  // mistaken for a valid quoted literal.
-  for (const match of arrayContent.matchAll(/'([^']+)'|"([^"]+)"/g)) {
-    const value = match[1] ?? match[2] ?? '';
-    const matchIndex = match.index ?? 0;
+  for (const token of scanQuotedLiterals(arrayContent, `'"`)) {
+    const matchIndex = token.index;
     while (cursor < newlineOffsets.length && newlineOffsets[cursor] < matchIndex) {
       cursor++;
     }
     const actualLine0 = startLine0 + cursor;
     if (ignoredLines.has(actualLine0)) continue;
-    addClasses(results, value, actualLine0 + 1);
+    addClasses(results, token.value, actualLine0 + 1);
   }
 }
 


### PR DESCRIPTION
Closes #139

---

## Summary

`extractFromCallArgs` / `extractFromClassListArray` used naive per-token regexes with no backslash-escape awareness — an escaped quote (`\'`, `\"`) inside one call argument desynced token boundaries for every following argument, in some quote-parity cases **silently dropping a sibling argument's real violation** (e.g. `cn('it\'s', 'p-4')` dropped `p-4`).

## Fix

Added `scanQuotedLiterals()` — a char-by-char scanner (mirroring `scanBalancedDelimited`'s existing escape handling: `\` consumes the next char, so `\'`/`\"`/`\\` never close the string) — and routed both extraction paths through it. Tokens must open/close with the same quote char (preserves prior mismatched-quote behavior).

## Tests

+5 in `src/extractor.test.ts`: escaped-quote sibling-violation repros (single, double, mixed), `class:list` array variant, escaped-quote token pinned verbatim; re-pinned the #133 regression with its corrected (no-longer-fragmented) output. Suite 660 → **665** green.

🤖 Raised + auto-fixed by `/x-wt-teams` (epic #122 follow-up).